### PR TITLE
Syntax Changes and ToolTip naming fix

### DIFF
--- a/frontend/src/components/Form/Form.tsx
+++ b/frontend/src/components/Form/Form.tsx
@@ -2,302 +2,283 @@ import React, { useState, useRef, useEffect } from "react";
 import FormElement from "../FormElement/FormElement";
 import axios from "axios";
 import {
-	InformationFormConfig,
-	IncidentFormConfig,
-	checkboxDataConfig,
+  InformationFormConfig,
+  IncidentFormConfig,
+  checkboxDataConfig,
 } from "../../utils/formRowsConfig";
 import Spacer from "../Spacer/Spacer";
 import "./Form.css";
-import ToolTip from "../ToolTip/ToolTip";
-interface Form {}
+import ToolTipp from "../ToolTip/ToolTip";
 
-const Form: React.FC<Form> = ({}) => {
-	const formRef = useRef<HTMLFormElement>(null);
-	const [forms, setForms] = useState<{ [key: string]: boolean }>({});
-	const [fields, setFields] = useState<string[]>([]);
-	const [checkboxData, setCheckboxData] = useState<{
-		[key: string]: boolean;
-	}>({});
-	const [isLoading, setIsLoading] = useState(false);
+export default function Form() {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [forms, setForms] = useState<{ [key: string]: boolean }>({});
+  const [fields, setFields] = useState<string[]>([]);
+  const [checkboxData, setCheckboxData] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const [isLoading, setIsLoading] = useState(false);
 
-	useEffect(() => {
-		const fetchForms = async () => {
-			setIsLoading(true);
-			try {
-				const response = await axios.get(
-					"http://127.0.0.1:9000/get_forms",
-					{
-						headers: {
-							"Content-Type": "application/json",
-							// Additional headers if needed
-						},
-					}
-				);
+  useEffect(() => {
+    const fetchForms = async () => {
+      setIsLoading(true);
+      try {
+        const response = await axios.get("http://127.0.0.1:9000/get_forms", {
+          headers: {
+            "Content-Type": "application/json",
+            // Additional headers if needed
+          },
+        });
 
-				const data = response.data;
-				const newForm: { [key: string]: boolean } = {};
+        const data = response.data;
+        const newForm: { [key: string]: boolean } = {};
 
-				for (const form of data["forms"]) {
-					newForm[form] = true;
-				}
-				setForms(newForm);
-			} catch (error) {
-				// Handle any errors that occurred during the fetch
-				console.error("ERROR", error);
-			} finally {
-				setIsLoading(false);
-			}
-		};
-		fetchForms();
+        for (const form of data["forms"]) {
+          newForm[form] = true;
+        }
+        setForms(newForm);
+      } catch (error) {
+        // Handle any errors that occurred during the fetch
+        console.error("ERROR", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchForms();
 
-		// const data = checkboxDataConfig.map((item) => item.initialize_data);
-		// const checkboxInitialData = Object.assign({}, ...data);
-		const checkboxInitialData = Object.assign(
-			{},
-			...checkboxDataConfig.map((item) => item.initialize_data)
-		);
-		setCheckboxData(checkboxInitialData);
-		// Now we need to iterate through and udpdate checkBoxData
-	}, []); // Empty dependency array ensures this runs once on mount
+    // const data = checkboxDataConfig.map((item) => item.initialize_data);
+    // const checkboxInitialData = Object.assign({}, ...data);
+    const checkboxInitialData = Object.assign(
+      {},
+      ...checkboxDataConfig.map((item) => item.initialize_data)
+    );
+    setCheckboxData(checkboxInitialData);
+    // Now we need to iterate through and udpdate checkBoxData
+  }, []); // Empty dependency array ensures this runs once on mount
 
-	// * When we update forms, then the fields need to change! The fields show what inputs display
-	// * Forms show which forms display.
-	useEffect(() => {
-		const updateFields = async (formsNeeded: string[]) => {
-			const postData = { forms: formsNeeded };
-			// console.log("POST DATA", postData);
-			try {
-				// Replace with your API endpoint
-				const response = await axios.post(
-					"http://127.0.0.1:9000/get_fields",
-					postData,
-					{
-						headers: {
-							"Content-Type": "application/json",
-							// Additional headers if needed
-						},
-					}
-				);
+  // * When we update forms, then the fields need to change! The fields show what inputs display
+  // * Forms show which forms display.
+  useEffect(() => {
+    const updateFields = async (formsNeeded: string[]) => {
+      const postData = { forms: formsNeeded };
+      // console.log("POST DATA", postData);
+      try {
+        // Replace with your API endpoint
+        const response = await axios.post(
+          "http://127.0.0.1:9000/get_fields",
+          postData,
+          {
+            headers: {
+              "Content-Type": "application/json",
+              // Additional headers if needed
+            },
+          }
+        );
 
-				// Check if the response status is OK (200)
-				if (response.status !== 200) {
-					throw new Error("Network response was not ok");
-				}
-				// Parse the response as JSON
-				const data = response.data["data"]["keys"];
-				// Handle the data (e.g., console.log or set a state)
-				// console.log("get_fields data", data);
-				setFields(data);
-			} catch (error) {
-				console.error("ERROR", error);
-			}
-		};
+        // Check if the response status is OK (200)
+        if (response.status !== 200) {
+          throw new Error("Network response was not ok");
+        }
+        // Parse the response as JSON
+        const data = response.data["data"]["keys"];
+        // Handle the data (e.g., console.log or set a state)
+        // console.log("get_fields data", data);
+        setFields(data);
+      } catch (error) {
+        console.error("ERROR", error);
+      }
+    };
 
-		if (Object.keys(forms).length > 0) {
-			updateFields(
-				Object.keys(forms).filter((key) => forms[key] === true)
-			);
-		} else {
-			setFields([]);
-		}
-	}, [forms]); // Dependency array with 'forms' state
+    if (Object.keys(forms).length > 0) {
+      updateFields(Object.keys(forms).filter((key) => forms[key] === true));
+    } else {
+      setFields([]);
+    }
+  }, [forms]); // Dependency array with 'forms' state
 
-	// * Handle submit
-	const formatSubmitData = () => {
-		const data: {
-			data: {
-				[key: string]: FormDataEntryValue | string | boolean | any;
-			};
-			forms: string[];
-		} = {
-			data: {},
-			forms: [],
-		};
+  // * Handle submit
+  const formatSubmitData = () => {
+    const data: {
+      data: {
+        [key: string]: FormDataEntryValue | string | boolean | any;
+      };
+      forms: string[];
+    } = {
+      data: {},
+      forms: [],
+    };
 
-		if (formRef.current) {
-			const formData = new FormData(formRef.current);
+    if (formRef.current) {
+      const formData = new FormData(formRef.current);
 
-			formData.forEach((value, key) => {
-				data["data"][key] = value;
-			});
-		}
+      formData.forEach((value, key) => {
+        data["data"][key] = value;
+      });
+    }
 
-		Object.entries(checkboxData).forEach(([key, value]) => {
-			data["data"][key] = value;
-		});
+    Object.entries(checkboxData).forEach(([key, value]) => {
+      data["data"][key] = value;
+    });
 
-		data["forms"] = Object.keys(forms).filter((key) => forms[key] == true);
-		return data;
-	};
+    data["forms"] = Object.keys(forms).filter((key) => forms[key] == true);
+    return data;
+  };
 
-	const handleSubmit = async (event: React.FormEvent) => {
-		event.preventDefault();
-		setIsLoading(true);
-		const submit_data = formatSubmitData();
-		console.log("Submit data", submit_data);
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsLoading(true);
+    const submit_data = formatSubmitData();
+    console.log("Submit data", submit_data);
 
-		try {
-			// Replace with your API endpoint
-			const response = await axios.post(
-				"http://127.0.0.1:9000/submit_form",
-				submit_data,
-				{
-					headers: {
-						"Content-Type": "application/json",
-						// Additional headers if needed
-					},
-				}
-			);
-			// Parse the response as JSON
-			const data = response.data;
-			console.log("Response data", data);
-		} catch (error: any) {
-			console.log("Submit form error:", error.response.data);
-			// console.error("ERROR", error);
-		} finally {
-			setIsLoading(false);
-		}
-	};
+    try {
+      // Replace with your API endpoint
+      const response = await axios.post(
+        "http://127.0.0.1:9000/submit_form",
+        submit_data,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            // Additional headers if needed
+          },
+        }
+      );
+      // Parse the response as JSON
+      const data = response.data;
+      console.log("Response data", data);
+    } catch (error: any) {
+      console.log("Submit form error:", error.response.data);
+      // console.error("ERROR", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-	if (isLoading) {
-		return (
-			<img className="form-container" src="https://media1.giphy.com/media/3oEjI6SIIHBdRxXI40/200w.gif?cid=6c09b952kqaz9oyscryqv4hzi7gj3yetccv96vuqesw5af73&ep=v1_gifs_search&rid=200w.gif&ct=g" />
-		);
-	}
+  if (isLoading) {
+    return (
+      <img
+        className="form-container"
+        src="https://media1.giphy.com/media/3oEjI6SIIHBdRxXI40/200w.gif?cid=6c09b952kqaz9oyscryqv4hzi7gj3yetccv96vuqesw5af73&ep=v1_gifs_search&rid=200w.gif&ct=g"
+      />
+    );
+  }
 
-	return (
-		<form ref={formRef} className="form-container" onSubmit={handleSubmit}>
-			<div>
-				<span className="asterisk">*</span>
-				<span className="information"> </span>
-				<span className="required">Required</span>
-			</div>
-			<div className="subheader">Send my report to:</div>
+  return (
+    <form ref={formRef} className="form-container" onSubmit={handleSubmit}>
+      <div>
+        <span className="asterisk">*</span>
+        <span className="information"> </span>
+        <span className="required">Required</span>
+      </div>
+      <div className="subheader">Send my report to:</div>
 
-			{/* Forms checkbox */}
-			<div id="checkbox-style">
-				{Object.entries(forms).map(([form_name, form_active]) => (
-					<div key={form_name}>
-						<input
-							type="checkbox"
-							id={form_name}
-							onChange={() =>
-								setForms((prevForms) => {
-									return {
-										...prevForms,
-										[form_name]: !prevForms[form_name],
-									};
-								})
-							}
-							checked={form_active}
-							required={!Object.values(forms).includes(true)}
-						></input>
-						<label htmlFor={form_name}>
-							{form_name.toUpperCase()}
-						</label>
-					</div>
-				))}
-			</div>
+      {/* Forms checkbox */}
+      <div id="checkbox-style">
+        {Object.entries(forms).map(([form_name, form_active]) => (
+          <div key={form_name}>
+            <input
+              type="checkbox"
+              id={form_name}
+              onChange={() =>
+                setForms((prevForms) => {
+                  return {
+                    ...prevForms,
+                    [form_name]: !prevForms[form_name],
+                  };
+                })
+              }
+              checked={form_active}
+              required={!Object.values(forms).includes(true)}
+            ></input>
+            <label htmlFor={form_name}>{form_name.toUpperCase()}</label>
+          </div>
+        ))}
+      </div>
 
-			{/* Form selections! */}
+      {/* Form selections! */}
 
-			<Spacer height={20} />
+      <Spacer height={20} />
 
-			<div className="subheader">Enter your Information:</div>
+      <div className="subheader">Enter your Information:</div>
 
-			<div className="row">
-				{checkboxDataConfig.map((element: any) => {
-					if (
-						!Object.keys(element.initialize_data).every((key) =>
-							fields.includes(key)
-						)
-					) {
-						return null;
-					}
+      <div className="row">
+        {checkboxDataConfig.map((element: any) => {
+          if (
+            !Object.keys(element.initialize_data).every((key) =>
+              fields.includes(key)
+            )
+          ) {
+            return null;
+          }
 
-					return (
-						<div id="checkbox-style" key={element.labelText}>
-							<input
-								type="checkbox"
-								id={element.labelText}
-								onChange={() => {
-									Object.keys(element.initialize_data).map(
-										(key) => {
-											setCheckboxData((prev) => {
-												return {
-													...prev,
-													[key]: !prev[key],
-												};
-											});
-										}
-									);
-								}}
-							></input>
-							<ToolTip toolTipText={element.toolTipText}>
-								<label htmlFor={element.labelText}>
-									{element.labelText}
-								</label>
-							</ToolTip>
-						</div>
-					);
-				})}
-			</div>
+          return (
+            <div id="checkbox-style" key={element.labelText}>
+              <input
+                type="checkbox"
+                id={element.labelText}
+                onChange={() => {
+                  Object.keys(element.initialize_data).map((key) => {
+                    setCheckboxData((prev) => {
+                      return {
+                        ...prev,
+                        [key]: !prev[key],
+                      };
+                    });
+                  });
+                }}
+              ></input>
+              <ToolTipp toolTipText={element.toolTipText}>
+                <label htmlFor={element.labelText}>{element.labelText}</label>
+              </ToolTipp>
+            </div>
+          );
+        })}
+      </div>
 
-			<Spacer height={15} />
+      <Spacer height={15} />
 
-			{loadSection(InformationFormConfig, fields)}
+      {loadSection(InformationFormConfig, fields)}
 
-			<Spacer height={20} />
+      <Spacer height={20} />
 
-			<div className="subheader">Incident details:</div>
+      <div className="subheader">Incident details:</div>
 
-			{loadSection(IncidentFormConfig, fields)}
+      {loadSection(IncidentFormConfig, fields)}
 
-			<Spacer height={20} />
+      <Spacer height={20} />
 
-			<button id="submit-button">
-				Submit
-				<img
-					id="send-symbol"
-					src="/iconamoon_send-light.svg"
-					alt="Send"
-				/>
-			</button>
-		</form>
-	);
-};
-
-export default Form;
+      <button id="submit-button">
+        Submit
+        <img id="send-symbol" src="/iconamoon_send-light.svg" alt="Send" />
+      </button>
+    </form>
+  );
+}
 
 const loadSection = (
-	config: FormElement[][],
-	visibleRowInputNames: string[]
+  config: FormElement[][],
+  visibleRowInputNames: string[]
 ) => {
-	return (
-		<>
-			{config.map((row, rowIndex) => (
-				<div className="row" key={rowIndex}>
-					{row.map((element, elementIndex) => {
-						if (
-							!visibleRowInputNames.includes(
-								element.formRefInputName
-							)
-						) {
-							return null;
-						}
-						return (
-							<FormElement
-								labelText={element.labelText}
-								formType={element.formType}
-								formRefInputName={element.formRefInputName}
-								data={element.data}
-								key={elementIndex}
-								defaultValue={element.defaultValue}
-							></FormElement>
-						);
-					})}
-				</div>
-			))}
-		</>
-	);
+  return (
+    <>
+      {config.map((row, rowIndex) => (
+        <div className="row" key={rowIndex}>
+          {row.map((element, elementIndex) => {
+            if (!visibleRowInputNames.includes(element.formRefInputName)) {
+              return null;
+            }
+            return (
+              <FormElement
+                labelText={element.labelText}
+                formType={element.formType}
+                formRefInputName={element.formRefInputName}
+                data={element.data}
+                key={elementIndex}
+                defaultValue={element.defaultValue}
+              ></FormElement>
+            );
+          })}
+        </div>
+      ))}
+    </>
+  );
 };

--- a/frontend/src/components/FormElement/FormElement.tsx
+++ b/frontend/src/components/FormElement/FormElement.tsx
@@ -3,21 +3,8 @@ import { TextField } from "@mui/material";
 import FormControl from "@mui/material/FormControl";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
-// import Tooltip from "@mui/material/Tooltip"
-import Tooltip, { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
-import { styled } from "@mui/material/styles";
+import ToolTipp from "../ToolTip/ToolTip";
 import "./FormElement.css";
-
-const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
-  <Tooltip {...props} classes={{ popper: className }} />
-))(({}) => ({
-  [`& .${tooltipClasses.tooltip}`]: {
-    backgroundColor: "#f5f5f9",
-    color: "rgba(0, 0, 0, 0.87)",
-    maxWidth: 220,
-    fontSize: "14px",
-  },
-}));
 
 export default function FormElement({
   labelText,
@@ -103,49 +90,22 @@ export default function FormElement({
           <input
             type="file"
             accept="image/*"
-            // onChange={handleFileChange}
             style={{ display: "none" }}
             name={formRefInputName}
           />
         </label>
       );
     }
-    // else if (formType === "checkbox") {
-    // 	return (
-    // 		<div className="check-with-text">
-    // 			<input
-    // 				type="checkbox"
-    // 				id={labelText}
-    // 				defaultChecked={true}
-    // 				name={labelText}
-    // 				// onChange={handleCheckboxChange}
-    // 				// value={checkboxValue}
-    // 			/>
-    // 			<label htmlFor={labelText}>{labelText}</label>
-    // 		</div>
-    // 	);
-    // }
-    return <p>{formType} is not a valid type you dog</p>;
+    return <p>{formType} is not a valid type</p>;
   };
 
   return (
     <div className="form-item">
       {formType !== "checkbox" && (
-        <HtmlTooltip
-          placement="right"
-          title={
-            <React.Fragment>
-              {/* <Typography color="inherit">
-								Tooltip with HTML
-							</Typography> */}
-              {/* <em>{"And here's"}</em> <b>{"some"}</b>{" "} */}
-              {/* <u>{"amazing content"}</u>.{" "} */}
-              {"We won't share your name or any identifying information."}
-            </React.Fragment>
-          }
-        >
-          <p className="title-text">{labelText}</p>
-        </HtmlTooltip>
+        <ToolTipp
+          toolTipText="We won't share your name or any identifying information."
+          children={<p className="title-text">{labelText}</p>}
+        ></ToolTipp>
       )}
       {getType()}
     </div>

--- a/frontend/src/components/FormElement/FormElement.tsx
+++ b/frontend/src/components/FormElement/FormElement.tsx
@@ -9,151 +9,145 @@ import { styled } from "@mui/material/styles";
 import "./FormElement.css";
 
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
-	<Tooltip {...props} classes={{ popper: className }} />
+  <Tooltip {...props} classes={{ popper: className }} />
 ))(({}) => ({
-	[`& .${tooltipClasses.tooltip}`]: {
-		backgroundColor: "#f5f5f9",
-		color: "rgba(0, 0, 0, 0.87)",
-		maxWidth: 220,
-		fontSize: "14px",
-	},
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "#f5f5f9",
+    color: "rgba(0, 0, 0, 0.87)",
+    maxWidth: 220,
+    fontSize: "14px",
+  },
 }));
 
-interface FormElement {
-	labelText: string;
-	formType: string;
-	data?: string[];
-	defaultValue?: string;
-	formRefInputName: string;
-}
+export default function FormElement({
+  labelText,
+  formType,
+  data,
+  defaultValue,
+  formRefInputName,
+}: {
+  labelText: string;
+  formType: string;
+  data?: string[];
+  defaultValue?: string;
+  formRefInputName: string;
+}) {
+  const [selection, setSelection] = React.useState(defaultValue);
 
-const FormElement: React.FC<FormElement> = ({
-	labelText,
-	formType,
-	data = [],
-	defaultValue = "",
-	formRefInputName,
-}) => {
-	const [selection, setSelection] = React.useState(defaultValue);
+  const handleChange = (event: SelectChangeEvent) => {
+    setSelection(event.target.value);
+  };
 
-	const handleChange = (event: SelectChangeEvent) => {
-		setSelection(event.target.value);
-	};
+  const getType = () => {
+    if (formType === "text") {
+      return (
+        <TextField
+          name={formRefInputName}
+          id="outlined-basic"
+          variant="outlined"
+          size="small"
+          className="input-style"
+          required={true}
+        />
+      );
+    } else if (formType === "select") {
+      return (
+        <FormControl
+          sx={{ m: 0, minWidth: 0 }}
+          size="small"
+          className="input-style"
+        >
+          <Select
+            value={selection}
+            onChange={handleChange}
+            displayEmpty
+            inputProps={{ "aria-label": "Without label" }}
+            name={formRefInputName}
+            required={true}
+          >
+            {defaultValue ? (
+              <MenuItem value="Michigan">Michigan</MenuItem>
+            ) : (
+              <MenuItem value="">None</MenuItem>
+            )}
 
-	const getType = () => {
-		if (formType === "text") {
-			return (
-				<TextField
-					name={formRefInputName}
-					id="outlined-basic"
-					variant="outlined"
-					size="small"
-					className="input-style"
-					required={true}
-				/>
-			);
-		} else if (formType === "select") {
-			return (
-				<FormControl
-					sx={{ m: 0, minWidth: 0 }}
-					size="small"
-					className="input-style"
-				>
-					<Select
-						value={selection}
-						onChange={handleChange}
-						displayEmpty
-						inputProps={{ "aria-label": "Without label" }}
-						name={formRefInputName}
-						required={true}
-					>
-						{defaultValue ? (
-							<MenuItem value="Michigan">Michigan</MenuItem>
-						) : (
-							<MenuItem value="">None</MenuItem>
-						)}
+            {data.map((option) => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      );
+    } else if (formType === "time") {
+      return <p>hello</p>;
+    } else if (formType === "multiline-text") {
+      return (
+        <TextField
+          className="input-style"
+          multiline
+          rows={4}
+          name={formRefInputName}
+          required={true}
+        />
+      );
+    } else if (formType === "image") {
+      return (
+        <label className="image-button-style">
+          <img
+            src="/material-symbols_image-outline.svg"
+            alt="Icon"
+            className="icon-style"
+          />
+          <span className="text-style">Choose image</span>
+          <input
+            type="file"
+            accept="image/*"
+            // onChange={handleFileChange}
+            style={{ display: "none" }}
+            name={formRefInputName}
+          />
+        </label>
+      );
+    }
+    // else if (formType === "checkbox") {
+    // 	return (
+    // 		<div className="check-with-text">
+    // 			<input
+    // 				type="checkbox"
+    // 				id={labelText}
+    // 				defaultChecked={true}
+    // 				name={labelText}
+    // 				// onChange={handleCheckboxChange}
+    // 				// value={checkboxValue}
+    // 			/>
+    // 			<label htmlFor={labelText}>{labelText}</label>
+    // 		</div>
+    // 	);
+    // }
+    return <p>{formType} is not a valid type you dog</p>;
+  };
 
-						{data.map((option) => (
-							<MenuItem key={option} value={option}>
-								{option}
-							</MenuItem>
-						))}
-					</Select>
-				</FormControl>
-			);
-		} else if (formType === "time") {
-			return <p>hello</p>;
-		} else if (formType === "multiline-text") {
-			return (
-				<TextField
-					className="input-style"
-					multiline
-					rows={4}
-					name={formRefInputName}
-					required={true}
-				/>
-			);
-		} else if (formType === "image") {
-			return (
-				<label className="image-button-style">
-					<img
-						src="/material-symbols_image-outline.svg"
-						alt="Icon"
-						className="icon-style"
-					/>
-					<span className="text-style">Choose image</span>
-					<input
-						type="file"
-						accept="image/*"
-						// onChange={handleFileChange}
-						style={{ display: "none" }}
-						name={formRefInputName}
-					/>
-				</label>
-			);
-		} 
-		// else if (formType === "checkbox") {
-		// 	return (
-		// 		<div className="check-with-text">
-		// 			<input
-		// 				type="checkbox"
-		// 				id={labelText}
-		// 				defaultChecked={true}
-		// 				name={labelText}
-		// 				// onChange={handleCheckboxChange}
-		// 				// value={checkboxValue}
-		// 			/>
-		// 			<label htmlFor={labelText}>{labelText}</label>
-		// 		</div>
-		// 	);
-		// }
-		return <p>{formType} is not a valid type you dog</p>;
-	};
-
-	return (
-		<div className="form-item">
-			{formType !== "checkbox" && (
-				<HtmlTooltip
-					placement="right"
-					title={
-						<React.Fragment>
-							{/* <Typography color="inherit">
+  return (
+    <div className="form-item">
+      {formType !== "checkbox" && (
+        <HtmlTooltip
+          placement="right"
+          title={
+            <React.Fragment>
+              {/* <Typography color="inherit">
 								Tooltip with HTML
 							</Typography> */}
-							{/* <em>{"And here's"}</em> <b>{"some"}</b>{" "} */}
-							{/* <u>{"amazing content"}</u>.{" "} */}
-							{
-								"We won't share your name or any identifying information."
-							}
-						</React.Fragment>
-					}
-				>
-					<p className="title-text">{labelText}</p>
-				</HtmlTooltip>
-			)}
-			{getType()}
-		</div>
-	);
-};
-
-export default FormElement;
+              {/* <em>{"And here's"}</em> <b>{"some"}</b>{" "} */}
+              {/* <u>{"amazing content"}</u>.{" "} */}
+              {"We won't share your name or any identifying information."}
+            </React.Fragment>
+          }
+        >
+          <p className="title-text">{labelText}</p>
+        </HtmlTooltip>
+      )}
+      {getType()}
+    </div>
+  );
+}

--- a/frontend/src/components/ToolTip/ToolTip.tsx
+++ b/frontend/src/components/ToolTip/ToolTip.tsx
@@ -3,30 +3,29 @@ import Tooltip, { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
 import { styled } from "@mui/material/styles";
 
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
-	<Tooltip {...props} classes={{ popper: className }} />
+  <Tooltip {...props} classes={{ popper: className }} />
 ))(({}) => ({
-	[`& .${tooltipClasses.tooltip}`]: {
-		backgroundColor: "#f5f5f9",
-		color: "rgba(0, 0, 0, 0.87)",
-		maxWidth: 220,
-		fontSize: "14px",
-	},
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "#f5f5f9",
+    color: "rgba(0, 0, 0, 0.87)",
+    maxWidth: 220,
+    fontSize: "14px",
+  },
 }));
 
-interface FormElement {
-	toolTipText: string;
-	children: ReactElement<any, any>;
+export default function ToolTipp({
+  toolTipText,
+  children,
+}: {
+  toolTipText: string;
+  children: ReactElement<any, any>;
+}) {
+  return (
+    <HtmlTooltip
+      placement="right"
+      title={<React.Fragment>{toolTipText}</React.Fragment>}
+    >
+      {children}
+    </HtmlTooltip>
+  );
 }
-
-const FormElement: React.FC<FormElement> = ({ toolTipText, children }) => {
-	return (
-		<HtmlTooltip
-			placement="right"
-			title={<React.Fragment>{toolTipText}</React.Fragment>}
-		>
-			{children}
-		</HtmlTooltip>
-	);
-};
-
-export default FormElement;

--- a/frontend/src/mainpage.tsx
+++ b/frontend/src/mainpage.tsx
@@ -8,7 +8,6 @@ import Dialog from "@mui/material/Dialog";
 import { TransitionProps } from "@mui/material/transitions";
 import { Slide } from "@mui/material";
 import CLOSEICON_PATH from "./assets/ic_round-close.svg";
-import { Padding } from "@mui/icons-material";
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & {
@@ -19,7 +18,7 @@ const Transition = React.forwardRef(function Transition(
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const MainPage: React.FC = () => {
+export default function MainPage() {
   // const formRef = useRef<HTMLFormElement>(null);
   // const [complete, onComplete] = useState(false);
   //const [value, onChange] = useState<Value>(new Date());
@@ -142,6 +141,4 @@ const MainPage: React.FC = () => {
       )}
     </main>
   );
-};
-
-export default MainPage;
+}


### PR DESCRIPTION
- Changed to use traditional JavaScript function declaration (export default function FunctionName() { ... } wherever possible.

- removed use of interfaces, just put it into function declaration instead

- renamed ToolTip custom component from FormElement to 'ToolTipp' (was confusing why it had the same name as the actual FormElement)